### PR TITLE
add a macro "format_code"

### DIFF
--- a/cmake/clang-format.cmake
+++ b/cmake/clang-format.cmake
@@ -1,0 +1,44 @@
+#
+# @file clang-format.cmake
+# @author Maximilien Naveau
+# @copyright Copyright (c) 2019, New York University and Max Planck Gesellschaft.
+# @license License BSD-3 clause
+# @date 2019-10-16
+#
+#===============================================================================
+# Code Formatting
+#===============================================================================
+
+MACRO(FORMAT_CODE)
+
+    option(FORMAT_CODE_DURING_BUILD "Set to ON if you want to format your code automatically during the build" OFF)
+
+    if(${FORMAT_CODE_DURING_BUILD})
+        message(STATUS "[ Code Formatting ]")
+        find_program(
+            CLANG_FORMAT_EXECUTABLE
+            NAMES clang-format-6.0
+        )
+        if(CLANG_FORMAT_EXECUTABLE)
+            message(STATUS "Looking for clang-format - found")
+            message(STATUS "Format source files using catkin_make format.")
+            configure_file(${mpi_cmake_modules_SOURCE_DIR}/resources/.clang-format.in
+                        ${CMAKE_CURRENT_SOURCE_DIR}/.clang_format @ONLY IMMEDIATE)
+            add_custom_target(${PROJECT_NAME}-format ALL
+                            COMMAND ${CMAKE_COMMAND} -E echo "Formatting files... "
+                            COMMAND ${mpi_cmake_modules_SOURCE_DIR}/resources/format.sh ${CLANG_FORMAT_EXECUTABLE}
+                            COMMAND ${CMAKE_COMMAND} -E echo "Done."
+                            DEPENDS ${CLANG_FORMAT_EXECUTABLE}
+                            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+            add_custom_target(${PROJECT_NAME}-check-format ALL
+                COMMAND ${CMAKE_COMMAND} -E echo "Checking files... "
+                COMMAND ${mpi_cmake_modules_SOURCE_DIR}/resources/check_format.sh ${CLANG_FORMAT_EXECUTABLE}
+                COMMAND ${CMAKE_COMMAND} -E echo "Done."
+                DEPENDS ${CLANG_FORMAT_EXECUTABLE}
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+        else()
+            message(WARNING "Looking for clang-format - NOT found, please install clang-format to enable automatic code formatting")
+        endif()
+    endif()
+  
+ENDMACRO(FORMAT_CODE)

--- a/resources/.clang-format.in
+++ b/resources/.clang-format.in
@@ -1,0 +1,112 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     119
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    false
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never
+...

--- a/resources/Doxyfile.in
+++ b/resources/Doxyfile.in
@@ -18,7 +18,9 @@ EXTRACT_STATIC         = YES
 INPUT                  = @PROJECT_SOURCE_DIR@/src \
                          @PROJECT_SOURCE_DIR@/include \
                          @PROJECT_SOURCE_DIR@/python \
-                         @PROJECT_SOURCE_DIR@/doc
+                         @PROJECT_SOURCE_DIR@/srcpy \
+                         @PROJECT_SOURCE_DIR@/doc \
+                         @PROJECT_SOURCE_DIR@/demos
 IMAGE_PATH             = @PROJECT_SOURCE_DIR@/doc/pictures \
                          @PROJECT_SOURCE_DIR@/doc/figures
 FILE_PATTERNS          = *.h *.hpp *.hh *.cpp *.c *.cc *.hxx *.py *.dox

--- a/resources/check_format.sh
+++ b/resources/check_format.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+if [ "$#" -lt 1 ]; then
+  echo "Usage: ./check_format.sh <clang-format-executable>" >&2
+  exit 0
+fi
+
+files=`find . -path ./cmake -prune -o -iregex '.*\.\(h\|c\|hh\|cc\|hpp\|cpp\|hxx\|cxx\)$' -print`
+num_changes=`$1 -style=file -output-replacements-xml $files | grep -c "<replacement "`
+
+if [ "$num_changes" = "0" ]; then
+  echo "Every file seems to comply with our code convention."
+  exit 0
+else
+  echo "Found" $num_changes "necessary changes."
+  exit 0
+fi

--- a/resources/format.sh
+++ b/resources/format.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+if [ "$#" -lt 1 ]; then
+  echo "Usage: ./check_format.sh <clang-format-executable>" >&2
+  exit 0
+fi
+
+files=`find . -path ./cmake -prune -o -iregex '.*\.\(h\|c\|hh\|cc\|hpp\|cpp\|hxx\|cxx\)$' -print`
+$1 -i $files
+
+echo $format_out
+if [ "$format" = "" ]; then
+  echo "Code formatted."
+  exit 0
+else
+  echo "Error while formatting: $format_out."
+  exit 0
+fi


### PR DESCRIPTION
## What changed?

-  that allow you to format your code automatically according to the copied .clang-format.in file in resources/

## How it works:

- 1/ developers will have to add the macro `FORMAT_CODE` in their CMakeLists.txt.
- 2/ developers can compile their code using: `catkin_make -DFORMAT_CODE_DURING_BUILD=ON`
And their codes are going to be automatically formated.

## To be done
update the .clang-format to satisfy mpi requierement