### PR TITLE
Set package path inside python.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,9 @@
 # @copyright Copyright (c) 2019, New York University and Max Planck Gesellschaft.
 # @license License BSD-3 clause
 # @date 2019-05-06
-# 
+#
 # @brief This file allow the build of this package using cmake
-# 
+#
 
 ######################
 # set up the project #
@@ -32,6 +32,13 @@ set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
 ###########################
 find_package(catkin REQUIRED)
 
+
+# Define some path variables for this package
+set(MPI_CMAKE_MODULES_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR})
+set(MPI_CMAKE_MODULES_CMAKE_DIR ${MPI_CMAKE_MODULES_ROOT_DIR}/cmake)
+set(MPI_CMAKE_MODULES_RESOURCES_DIR ${MPI_CMAKE_MODULES_ROOT_DIR}/resources)
+set(MPI_CMAKE_MODULES_SCRIPTS_DIR ${MPI_CMAKE_MODULES_ROOT_DIR}/scripts)
+
 ############################
 # Get all the files needed #
 ############################
@@ -46,7 +53,9 @@ endforeach()
 # export the package as a catkin package #
 ##########################################
 catkin_package(
-  CFG_EXTRAS ${cmake_files}
+  CFG_EXTRAS
+    ${MPI_CMAKE_MODULES_RESOURCES_DIR}/package_paths.cmake
+    ${cmake_files}
 )
 
 ##########################

--- a/cmake/clang-format.cmake
+++ b/cmake/clang-format.cmake
@@ -27,8 +27,8 @@ MACRO(FORMAT_CODE)
 
             # load the clang-format configuration
             execute_process(COMMAND
-                ${mpi_cmake_modules_SOURCE_DIR}/scripts/yaml2oneline
-                    ${mpi_cmake_modules_SOURCE_DIR}/resources/_clang-format
+                ${MPI_CMAKE_MODULES_SCRIPTS_DIR}/yaml2oneline
+                ${MPI_CMAKE_MODULES_RESOURCES_DIR}/_clang-format
                 RESULT_VARIABLE clang_format_conversion_result
                 OUTPUT_VARIABLE clang_format_config)
             if(NOT ${clang_format_conversion_result} EQUAL 0)
@@ -38,7 +38,7 @@ MACRO(FORMAT_CODE)
             # target to run clang-format to reformat the files
             add_custom_target(${PROJECT_NAME}-format ALL
                 COMMAND ${CMAKE_COMMAND} -E echo "Formatting files... "
-                COMMAND ${mpi_cmake_modules_SOURCE_DIR}/scripts/format.sh
+                COMMAND ${MPI_CMAKE_MODULES_SCRIPTS_DIR}/format.sh
                     ${CLANG_FORMAT_EXECUTABLE} "${clang_format_config}"
                 COMMAND ${CMAKE_COMMAND} -E echo "Done."
                 DEPENDS ${CLANG_FORMAT_EXECUTABLE}
@@ -47,7 +47,7 @@ MACRO(FORMAT_CODE)
             # target to check if formatting of files complies with style guide
             add_custom_target(${PROJECT_NAME}-check-format ALL
                 COMMAND ${CMAKE_COMMAND} -E echo "Checking files... "
-                COMMAND ${mpi_cmake_modules_SOURCE_DIR}/scripts/check_format.sh
+                COMMAND ${MPI_CMAKE_MODULES_SCRIPTS_DIR}/check_format.sh
                     ${CLANG_FORMAT_EXECUTABLE} "${clang_format_config}"
                 COMMAND ${CMAKE_COMMAND} -E echo "Done."
                 DEPENDS ${CLANG_FORMAT_EXECUTABLE} ${PROJECT_NAME}-format

--- a/cmake/clang-format.cmake
+++ b/cmake/clang-format.cmake
@@ -30,9 +30,14 @@ MACRO(FORMAT_CODE)
                 ${MPI_CMAKE_MODULES_SCRIPTS_DIR}/yaml2oneline
                 ${MPI_CMAKE_MODULES_RESOURCES_DIR}/_clang-format
                 RESULT_VARIABLE clang_format_conversion_result
-                OUTPUT_VARIABLE clang_format_config)
-            if(NOT ${clang_format_conversion_result} EQUAL 0)
-                message(FATAL_ERROR "Failed to load clang-format config.")
+                OUTPUT_VARIABLE clang_format_config
+                ERROR_VARIABLE clang_format_error_output)
+            if(NOT ${clang_format_error_output} STREQUAL "")
+                message(FATAL_ERROR "Failed to load clang-format config."
+                    " Error output: ${clang_format_error_output}")
+            elseif(NOT ${clang_format_conversion_result} EQUAL 0)
+                message(FATAL_ERROR "Failed to load clang-format config."
+                    " Return code: ${clang_format_conversion_result}")
             endif()
 
             # target to run clang-format to reformat the files

--- a/cmake/doxygen.cmake
+++ b/cmake/doxygen.cmake
@@ -34,13 +34,8 @@ macro(build_doxygen_documentation)
 
     # Create the doxyfile in function of the current project.
     # If the Doxyfile.in does not exists, the cmake step stops.
-    if(NOT ${mpi_cmake_modules_SOURCE_PREFIX} STREQUAL "")
-        set(RESOURCE_FOLDER ${mpi_cmake_modules_SOURCE_PREFIX}/resources)
-    elseif(NOT ${MPI_CMAKE_MODULES_RESOURCES_DIR} STREQUAL "")
-        set(RESOURCE_FOLDER ${MPI_CMAKE_MODULES_RESOURCES_DIR})
-    endif()
-
-    configure_file(${RESOURCE_FOLDER}/Doxyfile.in ${doc_build_folder}/Doxyfile
+    configure_file(${MPI_CMAKE_MODULES_RESOURCES_DIR}/Doxyfile.in
+                   ${doc_build_folder}/Doxyfile
                    @ONLY IMMEDIATE)
 
     # the doxygen target is generated

--- a/cmake/doxygen.cmake
+++ b/cmake/doxygen.cmake
@@ -4,20 +4,20 @@
 # @copyright Copyright (c) 2019, New York University and Max Planck Gesellschaft.
 # @license License BSD-3 clause
 # @date 2019-05-06
-# 
+#
 # @brief This file allows us to build the doxygen documentation of a package
 # using a simple macro
-# 
+#
 
 ##########################
 # building documentation #
 ##########################
 macro(build_doxygen_documentation)
-  
+
   set(BUILD_DOCUMENTATION OFF CACHE BOOL
       "Set to ON if you want to build the documentation")
   if(BUILD_DOCUMENTATION)
-  
+
     message(STATUS "building doxygen documentation for ${PROJECT_NAME}")
 
     # Find "doxygen"
@@ -31,25 +31,25 @@ macro(build_doxygen_documentation)
     # set the destination folder to be devel/share/[project_name]/doc/
     set(doc_build_folder ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION})
     set(doc_install_folder ${CMAKE_INSTALL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION})
-    
+
     # Create the doxyfile in function of the current project.
     # If the Doxyfile.in does not exists, the cmake step stops.
     if(NOT ${mpi_cmake_modules_SOURCE_PREFIX} STREQUAL "")
         set(RESOURCE_FOLDER ${mpi_cmake_modules_SOURCE_PREFIX}/resources)
-    elseif(NOT ${mpi_cmake_modules_SOURCE_DIR} STREQUAL "")
-        set(RESOURCE_FOLDER ${mpi_cmake_modules_SOURCE_DIR}/resources)
+    elseif(NOT ${MPI_CMAKE_MODULES_RESOURCES_DIR} STREQUAL "")
+        set(RESOURCE_FOLDER ${MPI_CMAKE_MODULES_RESOURCES_DIR})
     endif()
 
     configure_file(${RESOURCE_FOLDER}/Doxyfile.in ${doc_build_folder}/Doxyfile
                    @ONLY IMMEDIATE)
-    
+
     # the doxygen target is generated
     add_custom_target (${PROJECT_NAME}_doc ALL
       COMMAND ${DOXYGEN_EXECUTABLE} ${doc_build_folder}/Doxyfile
       SOURCES ${doc_build_folder}/Doxyfile
       WORKING_DIRECTORY ${doc_build_folder})
 
-    # install the documentation    
+    # install the documentation
     install(DIRECTORY ${doc_build_folder}/doc DESTINATION ${doc_install_folder})
     install(FILES ${doc_build_folder}/${PROJECT_NAME}.tag DESTINATION ${doc_install_folder})
   endif(BUILD_DOCUMENTATION)

--- a/cmake/python.cmake
+++ b/cmake/python.cmake
@@ -9,6 +9,10 @@
 # https://github.com/jrl-umi3218/jrl-cmakemodules/blob/master/python.cmake
 # 
 
+# set the path to the package root based on the location of this file
+set(mpi_cmake_modules_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/..)
+
+
 # NORMALIZE_PATH
 # ------------------
 #

--- a/cmake/python.cmake
+++ b/cmake/python.cmake
@@ -4,13 +4,10 @@
 # @copyright Copyright (c) 2019, New York University and Max Planck Gesellschaft.
 # @license License BSD-3 clause
 # @date 2019-05-06
-# 
+#
 # @brief This file is copied/inspired from
 # https://github.com/jrl-umi3218/jrl-cmakemodules/blob/master/python.cmake
-# 
-
-# set the path to the package root based on the location of this file
-set(mpi_cmake_modules_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/..)
+#
 
 
 # NORMALIZE_PATH
@@ -130,7 +127,7 @@ MACRO(DYNAMIC_GRAPH_PYTHON_MODULE SUBMODULENAME LIBRARYNAME TARGET_NAME)
   SET(PYTHON_MODULE "${TARGET_NAME}")
   ADD_LIBRARY(${PYTHON_MODULE}
     MODULE
-    ${mpi_cmake_modules_SOURCE_DIR}/resources/python-module-py.cc
+    ${MPI_CMAKE_MODULES_RESOURCES_DIR}/python-module-py.cc
   )
   MESSAGE(STATUS "Creating the python binding of: ${LIBRARYNAME}")
   TARGET_LINK_LIBRARIES(${PYTHON_MODULE} ${LIBRARYNAME} ${PYTHON_LIBRARY})
@@ -148,18 +145,18 @@ MACRO(DYNAMIC_GRAPH_PYTHON_MODULE SUBMODULENAME LIBRARYNAME TARGET_NAME)
   set(current_folder ${DYNAMIC_GRAPH_PYTHON_DIR})
   foreach(subfolder ${SUB_FOLDER_LIST})
     CONFIGURE_FILE(
-      ${mpi_cmake_modules_SOURCE_DIR}/resources/__init__.py.empty.in
+        ${MPI_CMAKE_MODULES_RESOURCES_DIR}/__init__.py.empty.in
       ${current_folder}/${subfolder}/__init__.py
     )
     set(current_folder ${current_folder}/${subfolder})
   endforeach(subfolder ${SUB_FOLDER_LIST})
-  
+
 
   # local var to create the destination folders and install it
   SET(OUTPUT_MODULE_DIR ${DYNAMIC_GRAPH_PYTHON_DIR}/${SUBMODULE_DIR})
 
   CONFIGURE_FILE(
-    ${mpi_cmake_modules_SOURCE_DIR}/resources/__init__.py.in
+    ${MPI_CMAKE_MODULES_RESOURCES_DIR}/__init__.py.in
     ${OUTPUT_MODULE_DIR}/__init__.py
   )
 

--- a/resources/Doxyfile.in
+++ b/resources/Doxyfile.in
@@ -29,7 +29,7 @@ RECURSIVE              = YES
 IMAGE_PATH             = @PROJECT_SOURCE_DIR@
 
 # Filter the python docstring as Doxygen ones.
-FILTER_PATTERNS = *.py=@RESOURCE_FOLDER@/py_filter
+FILTER_PATTERNS = *.py=@MPI_CMAKE_MODULES_RESOURCES_DIR@/py_filter
 
 # Remove the absolute path to the package from the file path.
 FULL_PATH_NAMES        = YES

--- a/resources/package_paths.cmake.in
+++ b/resources/package_paths.cmake.in
@@ -1,0 +1,13 @@
+#
+# @file
+# @author Felix Widmaier <felix.widmaier@tue.mpg.de>
+# @copyright Copyright (c) 2019, New York University and Max Planck Gesellschaft.
+# @license License BSD-3 clause
+#
+# @brief Export path variables to the mpi_cmake_modules package (so they can be
+# used in other files).
+
+set(MPI_CMAKE_MODULES_ROOT_DIR @MPI_CMAKE_MODULES_ROOT_DIR@)
+set(MPI_CMAKE_MODULES_CMAKE_DIR @MPI_CMAKE_MODULES_CMAKE_DIRS@)
+set(MPI_CMAKE_MODULES_RESOURCES_DIR @MPI_CMAKE_MODULES_RESOURCES_DIR@)
+set(MPI_CMAKE_MODULES_SCRIPTS_DIR @MPI_CMAKE_MODULES_SCRIPTS_DIR@)

--- a/scripts/yaml2oneline
+++ b/scripts/yaml2oneline
@@ -18,5 +18,5 @@ if __name__ == "__main__":
     filename = sys.argv[1]
 
     with open(filename, "r") as fh:
-        data = yaml.load(fh)
-        print(yaml.dump(data).replace("\n", ""))
+        data = yaml.load(fh, Loader=yaml.SafeLoader)
+        print(yaml.dump(data, default_flow_style=True).replace("\n", ""))


### PR DESCRIPTION
# Description
The `mpi_cmake_modules_SOURCE_DIR` variable needs to be set inside
python.cmake, otherwise the variable will be empty when using isolated
build.

# Do not merge yet
The same probably needs to be done in some other files as well.