### PR TITLE
update the doxyfile to depend on doxypypy.

### DIFF
--- a/cmake/doxygen.cmake
+++ b/cmake/doxygen.cmake
@@ -35,12 +35,13 @@ macro(build_doxygen_documentation)
     # Create the doxyfile in function of the current project.
     # If the Doxyfile.in does not exists, the cmake step stops.
     if(NOT ${mpi_cmake_modules_SOURCE_PREFIX} STREQUAL "")
-        configure_file(${mpi_cmake_modules_SOURCE_PREFIX}/resources/Doxyfile.in
-                       ${doc_build_folder}/Doxyfile  @ONLY IMMEDIATE)
+        set(RESOURCE_FOLDER ${mpi_cmake_modules_SOURCE_PREFIX}/resources)
     elseif(NOT ${mpi_cmake_modules_SOURCE_DIR} STREQUAL "")
-        configure_file(${mpi_cmake_modules_SOURCE_DIR}/resources/Doxyfile.in
-                    ${doc_build_folder}/Doxyfile  @ONLY IMMEDIATE)
+        set(RESOURCE_FOLDER ${mpi_cmake_modules_SOURCE_DIR}/resources)
     endif()
+
+    configure_file(${RESOURCE_FOLDER}/Doxyfile.in ${doc_build_folder}/Doxyfile
+                   @ONLY IMMEDIATE)
     
     # the doxygen target is generated
     add_custom_target (${PROJECT_NAME}_doc ALL

--- a/resources/Doxyfile.in
+++ b/resources/Doxyfile.in
@@ -5,7 +5,8 @@
 # @license License BSD-3 clause
 # @date 2019-05-06
 # 
-# @brief see doxygen.cmake for details.
+# @brief This file is the parameter file for the Doxygen ouput. All the variables
+# surrounded by "@" are CMake variable. See doxygen.cmake for details.
 # 
 
 PROJECT_NAME           = "@PROJECT_NAME@"
@@ -15,19 +16,47 @@ TAB_SIZE               = 4
 EXTRACT_ALL            = NO
 EXTRACT_PRIVATE        = NO
 EXTRACT_STATIC         = YES
+
+# Add exmaples form this folder.
 EXAMPLE_PATH           = @PROJECT_SOURCE_DIR@/demos
+
+# Look for any files in this folder ...(see RECURSIVE)
 INPUT                  = @PROJECT_SOURCE_DIR@
+# (see INPUT)... and recursively.
+RECURSIVE              = YES
+
+# Set the root path for the images.
 IMAGE_PATH             = @PROJECT_SOURCE_DIR@
-FILE_PATTERNS          = *.h *.hpp *.hh *.cpp *.c *.cc *.hxx *.py *.dox *.md
+
+# Filter the python docstring as Doxygen ones.
+FILTER_PATTERNS = *.py=@RESOURCE_FOLDER@/py_filter
+
+# Remove the absolute path to the pacakge from the file path.
+FULL_PATH_NAMES        = YES
+STRIP_FROM_PATH        = @PROJECT_SOURCE_DIR@/../
+
+# Get all the intersting files by looking for them recursively and according to
+# their extension
+FILE_PATTERNS          = *.h *.hpp *.hh *.cpp *.c *.cc *.hxx *.dox *.md *.py
+
+# Side bar with the tree.
+GENERATE_TREEVIEW = YES
+
+# remove the useless folders from the documentation.
 EXCLUDE_PATTERNS       = */*deprecated*/*
 EXCLUDE_PATTERNS      += */*build*/*
 EXCLUDE_PATTERNS      += */tests/*
-RECURSIVE              = YES
-GENERATE_LATEX         = YES
+
 GENERATE_TAGFILE       = @PROJECT_NAME@.tag
-GENERATE_TREEVIEW = YES
-GENERATE_HTML = YES
+GENERATE_HTML          = YES
+GENERATE_XML           = YES
+
+# Include and resize and image.
 ALIASES += imageSize{3}="\htmlonly <style> div.image img[src=\"\1\"]{\2} </style> \endhtmlonly \image html \1 \"\3\""
+
+# Allow searching from teh client side.
+SERVER_BASED_SEARCH = NO
+SEARCHENGINE        = YES
 
 # TODO manage this tag file with the cmake macro:
 # e.g. "@CMAKE_INSTALL_PREFIX@/share/doc/@DEPENDENCY_PROJECT@.doxytag = @CMAKE_INSTALL_PREFIX@/share/doc/@DEPENDENCY_PROJECT_NAME"

--- a/resources/Doxyfile.in
+++ b/resources/Doxyfile.in
@@ -31,7 +31,7 @@ IMAGE_PATH             = @PROJECT_SOURCE_DIR@
 # Filter the python docstring as Doxygen ones.
 FILTER_PATTERNS = *.py=@RESOURCE_FOLDER@/py_filter
 
-# Remove the absolute path to the pacakge from the file path.
+# Remove the absolute path to the package from the file path.
 FULL_PATH_NAMES        = YES
 STRIP_FROM_PATH        = @PROJECT_SOURCE_DIR@/../
 

--- a/resources/py_filter
+++ b/resources/py_filter
@@ -1,0 +1,2 @@
+#!/bin/bash
+doxypypy -a -c $1


### PR DESCRIPTION
# What changed?

This PR adds a dependency to doxypypy: `pip install doxypypy` 
It allows Doxygen to parse the python docstrings (Google format is the best yet),
and to use Doxygen own special commands in Python as well.

# How did I tested it?

I wrote the Doxygen/Google documentation of the ci_example_python package.