### PR TITLE
added setup_xenomai.cmake

### DIFF
--- a/cmake/XenomaiConfig.cmake
+++ b/cmake/XenomaiConfig.cmake
@@ -1,0 +1,89 @@
+# (C) Copyright 2005-2012 Johns Hopkins University (JHU), All Rights
+# Reserved.
+#
+# --- begin cisst license - do not edit ---
+# 
+# This software is provided "as is" under an open source license, with
+# no warranty.  The complete license can be found in license.txt and
+# http://www.cisst.org/cisst/license.txt.
+# 
+# --- end cisst license ---
+
+if( UNIX )
+
+  # set the search paths
+  set( Xenomai_SEARCH_PATH /usr/local /usr $ENV{XENOMAI_ROOT_DIR})
+  
+  # find xeno_config.h
+  find_path( Xenomai_INCLUDE_DIR
+    xeno_config.h 
+    PATHS ${Xenomai_SEARCH_PATH} 
+    PATH_SUFFIXES xenomai include xenomai/include include/xenomai
+    )
+
+  # did we find xeno_config.h?
+  if(Xenomai_INCLUDE_DIR) 
+    MESSAGE(STATUS "xenomai found: \"${Xenomai_INCLUDE_DIR}\"")
+    
+    # set the root directory
+    if( "${Xenomai_INCLUDE_DIR}" MATCHES "/usr/include/xenomai" )
+      # on ubuntu linux, xenomai install is not rooted to a single dir
+      set( Xenomai_ROOT_DIR /usr)
+      set( Xenomai_INCLUDE_POSIX_DIR ${Xenomai_INCLUDE_DIR}/posix )
+    else()
+      # elsewhere, xenomai install is packaged
+      get_filename_component(Xenomai_ROOT_DIR ${Xenomai_INCLUDE_DIR} PATH)
+      set( Xenomai_INCLUDE_POSIX_DIR ${Xenomai_ROOT_DIR}/include/posix )
+    endif()
+    
+    # Find xeno-config
+    find_program(Xenomai_XENO_CONFIG NAMES xeno-config  PATHS ${Xenomai_ROOT_DIR}/bin NO_DEFAULT_PATH)
+
+    # get version
+    execute_process(COMMAND ${Xenomai_XENO_CONFIG} --version OUTPUT_VARIABLE Xenomai_VERSION)
+
+    # find the xenomai pthread library
+    find_library( Xenomai_LIBRARY_NATIVE  native  ${Xenomai_ROOT_DIR}/lib )
+    find_library( Xenomai_LIBRARY_XENOMAI xenomai ${Xenomai_ROOT_DIR}/lib )
+    find_library( Xenomai_LIBRARY_PTHREAD_RT pthread_rt rtdm ${Xenomai_ROOT_DIR}/lib )
+    find_library( Xenomai_LIBRARY_RTDM    rtdm    ${Xenomai_ROOT_DIR}/lib )
+    if("${Xenomai_VERSION}" VERSION_LESS "2.6")
+      find_library( Xenomai_LIBRARY_RTDK    rtdk    ${Xenomai_ROOT_DIR}/lib )
+    endif()
+
+    set(Xenomai_LIBRARIES_NATIVE ${Xenomai_LIBRARY_NATIVE} ${Xenomai_LIBRARY_XENOMAI} pthread)
+    set(Xenomai_LIBRARIES_POSIX ${Xenomai_LIBRARY_PTHREAD_RT} ${Xenomai_LIBRARY_XENOMAI} pthread rt)
+
+    # Linker flags for the posix wrappers
+    set(Xenomai_LDFLAGS_NATIVE "")#"-lnative -lxenomai -lpthread -lrt")
+    set(Xenomai_LDFLAGS_POSIX "-Wl,@${Xenomai_ROOT_DIR}/lib/posix.wrappers")#-lpthread_rt -lxenomai -lpthread -lrt")
+
+    # add compile/preprocess options
+    set(Xenomai_DEFINITIONS -D_GNU_SOURCE -D_REENTRANT -pipe -D__XENO__)
+    set(Xenomai_DEFINITIONS_POSIX ${Xenomai_DEFINITIONS})
+
+
+    # set the library dirs
+    set( Xenomai_LIBRARY_DIRS ${Xenomai_ROOT_DIR}/lib )
+
+  else( )
+    MESSAGE(STATUS "xenomai NOT found. (${Xenomai_SEARCH_PATH})")
+  endif( )
+
+endif( UNIX )
+
+include(FindPackageHandleStandardArgs)
+
+set(Xenomai_REQUIRED_VARS 
+  Xenomai_ROOT_DIR
+  Xenomai_LIBRARY_NATIVE
+  Xenomai_LIBRARY_XENOMAI
+  Xenomai_LIBRARY_PTHREAD_RT
+  Xenomai_LIBRARY_RTDM
+  Xenomai_VERSION
+  )
+if("${Xenomai_VERSION}" VERSION_LESS "2.6")
+  set(Xenomai_REQUIRED_VARS ${Xenomai_REQUIRED_VARS} Xenomai_LIBRARY_RTDK)
+endif()
+
+find_package_handle_standard_args(Xenomai DEFAULT_MSG ${Xenomai_REQUIRED_VARS})

--- a/cmake/global_calls.cmake
+++ b/cmake/global_calls.cmake
@@ -1,0 +1,25 @@
+#
+# @file global_calls.cmake
+# @author Vincent Berenz / Maximilien Naveau
+# @copyright Copyright (c) 2019, New York University and Max Planck Gesellschaft.
+# @license License BSD-3 clause
+# @date 2020-01-06
+# 
+# @brief call macros for all catkin packages importing mpi_cmake_modules
+# 
+
+include(${CMAKE_CURRENT_LIST_DIR}/os_detection.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/setup_xenomai.cmake)
+
+# defining -DXENOMAI, -DRT_PREEMPT or -DNON_REAL_TIME
+# based on 'uname -a' command
+DEFINE_OS()
+
+# if os is xenomami, setting up Xenomai_LIBS, calling
+# xeno-config, and adding correct directory for include
+# and linkage
+if(CURRENT_OS STREQUAL "xenomai")
+  SETUP_XENOMAI()
+else()
+  set(Xenomai_LIBS pthread edit curses nsl glut GL GLU X11 Xmu m)
+endif()

--- a/cmake/os_detection.cmake
+++ b/cmake/os_detection.cmake
@@ -26,6 +26,7 @@ macro(DEFINE_OS)
       OUTPUT_VARIABLE UNAME_OUT)
   string(TOLOWER "${UNAME_OUT}" OS_VERSION)
 
+  set(OS_VERSION "preempt-rt")
 
   if(OS_VERSION MATCHES "xenomai")
     set(CURRENT_OS "xenomai")

--- a/cmake/os_detection.cmake
+++ b/cmake/os_detection.cmake
@@ -26,8 +26,6 @@ macro(DEFINE_OS)
       OUTPUT_VARIABLE UNAME_OUT)
   string(TOLOWER "${UNAME_OUT}" OS_VERSION)
 
-  set(OS_VERSION "preempt-rt")
-
   if(OS_VERSION MATCHES "xenomai")
     set(CURRENT_OS "xenomai")
     add_definitions("-DXENOMAI")
@@ -56,6 +54,3 @@ macro(DEFINE_OS)
 
 endmacro(DEFINE_OS)
 
-# We catually call the macro upon include of this cmake file so the OS is always
-# defined. This avoid verbosity in the CMakeLists.txt + potential error.
-DEFINE_OS()

--- a/cmake/setup_xenomai.cmake
+++ b/cmake/setup_xenomai.cmake
@@ -1,0 +1,50 @@
+#
+# @file setup_xenomai.cmake
+# @author Vincent Berenz (vberenz@tue.mpg.de)
+# @copyright Copyright (c) 2019, New York University and Max Planck Gesellschaft.
+# @license License BSD-3 clause
+# @date 2020-01-02
+# 
+# @brief setup Xenomai : 1) calls xeno-config , 2) add suitable libraries to linked
+# directories, 3) add suitable directories to include directories
+#  and 4) setup variable Xenomai_LIBS. Has been tested only on Xenomai 2.6.  
+# 
+
+macro(SETUP_XENOMAI)
+
+  message(WARNING "\n\n** compiling for xenomai **\n\n")
+
+  set (Xenomai_DIR "${CMAKE_CURRENT_LIST_DIR}/")
+  find_package(Xenomai REQUIRED)
+
+  set(XENOMAI_ROOT ${Xenomai_ROOT_DIR})
+
+  exec_program(${XENOMAI_ROOT}/bin/xeno-config ARGS "--skin=native --cflags" 
+      OUTPUT_VARIABLE XENOMAI_C_FLAGS)  
+  exec_program(${XENOMAI_ROOT}/bin/xeno-config ARGS "--skin=native --ldflags" 
+      OUTPUT_VARIABLE XENOMAI_LD_FLAGS)  
+  set(CMAKE_C_FLAGS "${XENOMAI_C_FLAGS} ${CMAKE_C_FLAGS}")
+  set(CMAKE_CPP_FLAGS "${XENOMAI_C_FLAGS} ${CMAKE_CPP_FLAGS}")
+  
+  set(Xenomai_LIBS native xenomai rtdm pthread edit curses nsl glut GL GLU X11 Xmu m)
+  if(Xenomai_LIBRARY_RTDK)
+    set(Xenomai_LIBS ${Xenomai_LIBS} rtdk)
+  endif()
+
+  link_directories(${XENOMAI_ROOT}/lib /usr/lib /usr/X11/lib64 /usr/X11/lib /usr/lib64 ${CMAKE_LIBRARY_PATH})
+
+  include_directories( ${Xenomai_INCLUDE_DIR} )
+
+endmacro(SETUP_XENOMAI)
+
+# calling setup_xenomai globally, to avoid cluttering
+# catkin packages. a lightweight Xenomai_LIBS variable is also defined 
+# for non xenomai os, also to avoid cluttering the catkin packages
+# (so that they can still safely link agains Xenomai_LIBS on non xenomai
+# os)
+DEFINE_OS()
+if(CURRENT_OS STREQUAL "xenomai")
+  SETUP_XENOMAI()
+else()
+  set(Xenomai_LIBS pthread edit curses nsl glut GL GLU X11 Xmu m)
+endif()

--- a/cmake/setup_xenomai.cmake
+++ b/cmake/setup_xenomai.cmake
@@ -37,14 +37,3 @@ macro(SETUP_XENOMAI)
 
 endmacro(SETUP_XENOMAI)
 
-# calling setup_xenomai globally, to avoid cluttering
-# catkin packages. a lightweight Xenomai_LIBS variable is also defined 
-# for non xenomai os, also to avoid cluttering the catkin packages
-# (so that they can still safely link agains Xenomai_LIBS on non xenomai
-# os)
-DEFINE_OS()
-if(CURRENT_OS STREQUAL "xenomai")
-  SETUP_XENOMAI()
-else()
-  set(Xenomai_LIBS pthread edit curses nsl glut GL GLU X11 Xmu m)
-endif()


### PR DESCRIPTION
## Issue solved
mpi_cmake_modules setup xenomai upon detection of xenomai patched os (as of os_detection macro).
"setup_xenomai" means adding the correct folders for includes and the correct libraries for linkage (+call to xenomai-config)

## how it was tested
real_time_tools (branch vberenz/xenomai) compiled ok on both non patched ubuntu 16.04 and patched ubuntu 14.04. 

## limitation
Xenomai 2.6 only