### PR TITLE
relative paths supported for clang_format executable

### DIFF
--- a/doc/clang_format.md
+++ b/doc/clang_format.md
@@ -18,6 +18,8 @@ And to run the following command:
 
     rosrun mpi_cmake_modules clang_format <list of files> <list of folders>
 
+<list_of_files> and <list of folders> can be either relative paths or absolute paths.
+
 For those not willing to use rosrun the executable is located in
 
     mpi_cmake_modules/scripts/clang_format

--- a/python/mpi_cmake_modules/_clang-format
+++ b/python/mpi_cmake_modules/_clang-format
@@ -1,0 +1,10 @@
+---
+BasedOnStyle: Google
+AccessModifierOffset: '-4'
+AllowShortFunctionsOnASingleLine: None
+BinPackArguments: 'false'
+BinPackParameters: 'false'
+BreakBeforeBraces: Allman
+IndentWidth: '4'
+
+...

--- a/python/mpi_cmake_modules/clang_format.py
+++ b/python/mpi_cmake_modules/clang_format.py
@@ -1,16 +1,3 @@
-#!/usr/bin/env python
-""" @namespace mpi_cmake_modules.clang_format
-Execute a clang-format on a desired file or folder.
-
-Usage example:
-- @code rosrun mpi_cmake_module clang_format /path/to/format @endcode
-- @code rosrun mpi_cmake_module clang_format file_to_format.ext @endcode
-
-@file
-@license License BSD-3-Clause
-@copyright Copyright (c) 2019, New York University and Max Planck Gesellschaft.
-"""
-
 import argparse
 import sys
 import os
@@ -48,7 +35,7 @@ def find_clang_format(name_list=['clang-format']):
 
 
 def load_clang_format_config():
-    """ Look for the clang-formt paramter file in this package.
+    """ Look for the clang-formt parameter file in this package.
     
     Look for the _clang-format file located in this package and convert it
     in a one line dictionnary string.
@@ -61,42 +48,49 @@ def load_clang_format_config():
             if "_clang-format" in filenames:
                 return yaml2oneline(path.join(dirpath, "_clang-format"))
             break
+    raise Exception("failed to find _clang-format file in "+str(mpi_cmake_modules.__path__))
 
-
-def test_valid_file(filename):
-    """ Test if the input file is a valid C/C++ file.
-    
-    Look at the extension of the file and return if it is a good one or not.
+def test_valid_file(filename,extensions):
+    """ Test if the input file exists and is of one of the provided extension.
 
     Args:
         filename: str `--` Path to the file to test.
+        extensions: iterable of accepted extensions (str)
     
     Returns:
-        True if the file ends with one of the following extension
-            (".h", ".c", ".hh", ".cc", ".hpp", ".cpp", ".hxx", ".cxx")
+        True if the file exits and ends with one of the extension.
         False otherwise.
     """
     if (path.isfile(filename) and any([filename.endswith(suffix) for suffix in
-                                       (".h", ".c", ".hh", ".cc", ".hpp",
-                                        ".cpp", ".hxx", ".cxx")])):
+                                       extensions])):
         return True
     else:
         return False
+    
 
+def get_absolute_path(file_or_directory):
+    """
+    Check if file_or_directory is an existing file or directory,
+    if so, returns it. Otherwise, assumes it is a relative path, 
+    which it upgrades to an absolute path, this it returns. If the 
+    upgraded path does not correspond to an existing file or directory,
+    returns None
 
-# either returns file_or_directory as such (if exists)
-# or assumes file_or_directory was a relative path and returns
-# the corresponding absolute path (if exist, None otherwise)
-def _get_full_path(file_or_directory):
+    Args:
+          file_or_directory: str `--` a relative or an absolute path
+
+    Returns:
+          an absolute existing path (str) or None
+    """
     if path.isfile(file_or_directory) or path.isdir(file_or_directory):
         return file_or_directory
-    fixed_path = os.path.abspath(os.getcwd()+os.sep+file_or_directory)
-    if os.isfile(fixed_path) or os.dir(fixed_path):
+    fixed_path = os.path.abspath(file_or_directory)
+    if path.isfile(fixed_path) or path.isdir(fixed_path):
         return fixed_path
     return None
         
     
-def list_of_files_to_format(files_or_directories):
+def list_of_files_to_format(files_or_directories,extensions):
     """ Get the list of files to format exploring the input arguments.
     
     Explore recursively the directories given in the input list and create
@@ -112,7 +106,7 @@ def list_of_files_to_format(files_or_directories):
             (".h", ".c", ".hh", ".cc", ".hpp", ".cpp", ".hxx", ".cxx")
         False otherwise.
     """
-    fixed = [_get_full_path(fod)
+    fixed = [get_absolute_path(fod)
              for fod in files_or_directories]
     for original,fix in zip(files_or_directories,fixed):
         if fix is None:
@@ -120,12 +114,12 @@ def list_of_files_to_format(files_or_directories):
     files_or_directories = fixed
     list_of_files = []
     for file_or_directory in files_or_directories:
-        if test_valid_file(file_or_directory):
+        if test_valid_file(file_or_directory,extensions):
             list_of_files.append(file_or_directory)
         elif path.isdir(file_or_directory):
             for (dirpath, _, filenames) in walk(file_or_directory):
                 for filename in filenames:
-                    if test_valid_file(path.join(dirpath, filename)):
+                    if test_valid_file(path.join(dirpath, filename),extensions):
                         list_of_files.append(path.join(dirpath, filename))
     return list_of_files
 
@@ -158,37 +152,3 @@ def execute_clang_format(clang_format_bin, clang_format_config,
         print(e)
 
 
-if __name__ == "__main__":
-    """ Format source files given or found recursively in the given folders """
-
-    ## Parser for the input arguments
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('files_or_folders', 
-                        ## Store the argument in files_or_folders.
-                        metavar='files_or_folders',
-                        ## Define the input argument type.
-                        type=str,
-                        ## ...
-                        nargs='+',
-                        ## Help string in case the argument is wrong.
-                        help='List of source files or folders.')
-    ## Input arguments.
-    args = parser.parse_args()
-    ## Path to the clang-format binary.
-    clang_format_bin = find_clang_format(['clang-format', 'clang-format-6.0',
-                                          'clang-format-8'])
-    ## clang-format parameters.
-    clang_format_config = load_clang_format_config()
-    ## List of files or directories to parse.
-    list_of_files = list_of_files_to_format(args.files_or_folders)
-
-    if not list_of_files:
-        raise RuntimeError(
-            "\nNo file to format, please indicate paths to files or directories.\n")
-    else :
-        print ("\nformatting:")
-        for f in list_of_files:
-            print ("\t"+str(f))
-        print ("")
-            
-    execute_clang_format(clang_format_bin, clang_format_config, list_of_files)

--- a/python/mpi_cmake_modules/clang_format.py
+++ b/python/mpi_cmake_modules/clang_format.py
@@ -84,6 +84,18 @@ def test_valid_file(filename):
         return False
 
 
+# either returns file_or_directory as such (if exists)
+# or assumes file_or_directory was a relative path and returns
+# the corresponding absolute path (if exist, None otherwise)
+def _get_full_path(file_or_directory):
+    if path.isfile(file_or_directory) or path.isdir(file_or_directory):
+        return file_or_directory
+    fixed_path = os.path.abspath(os.getcwd()+os.sep+file_or_directory)
+    if os.isfile(fixed_path) or os.dir(fixed_path):
+        return fixed_path
+    return None
+        
+    
 def list_of_files_to_format(files_or_directories):
     """ Get the list of files to format exploring the input arguments.
     
@@ -100,6 +112,12 @@ def list_of_files_to_format(files_or_directories):
             (".h", ".c", ".hh", ".cc", ".hpp", ".cpp", ".hxx", ".cxx")
         False otherwise.
     """
+    fixed = [_get_full_path(fod)
+             for fod in files_or_directories]
+    for original,fix in zip(files_or_directories,fixed):
+        if fix is None:
+            raise Exception("failed to find: "+str(original))
+    files_or_directories = fixed
     list_of_files = []
     for file_or_directory in files_or_directories:
         if test_valid_file(file_or_directory):
@@ -131,8 +149,9 @@ def execute_clang_format(clang_format_bin, clang_format_config,
                     ' -i ' + ' '.join(clang_format_arg)
                     ])
     try:
-        print ("executing: ")
+        print ("\nexecuting: ")
         print (cmd)
+        print ("")
         os.system(cmd)
     except Exception as e:
         print("Fail to call " + clang_format_bin + " with error:")
@@ -165,6 +184,11 @@ if __name__ == "__main__":
 
     if not list_of_files:
         raise RuntimeError(
-            "No file to format, please indicate paths to files or directories.")
-
+            "\nNo file to format, please indicate paths to files or directories.\n")
+    else :
+        print ("\nformatting:")
+        for f in list_of_files:
+            print ("\t"+str(f))
+        print ("")
+            
     execute_clang_format(clang_format_bin, clang_format_config, list_of_files)

--- a/resources/_clang-format
+++ b/resources/_clang-format
@@ -1,10 +1,1 @@
----
-BasedOnStyle: Google
-AccessModifierOffset: '-4'
-AllowShortFunctionsOnASingleLine: None
-BinPackArguments: 'false'
-BinPackParameters: 'false'
-BreakBeforeBraces: Allman
-IndentWidth: '4'
-
-...
+../python/mpi_cmake_modules/_clang-format

--- a/scripts/clang_format
+++ b/scripts/clang_format
@@ -1,1 +1,71 @@
-../python/mpi_cmake_modules/clang_format.py
+#!/usr/bin/env python
+
+""" @namespace mpi_cmake_modules.clang_format
+Execute a clang-format on a desired file or folder.
+
+Usage example:
+- @code rosrun mpi_cmake_module clang_format /path/to/format @endcode
+- @code rosrun mpi_cmake_module clang_format file_to_format.ext @endcode
+
+@file
+@license License BSD-3-Clause
+@copyright Copyright (c) 2019, New York University and Max Planck Gesellschaft.
+"""
+
+# cakin install has been called and install has been sourced
+from mpi_cmake_modules.clang_format import *
+
+def _execute():
+
+    ## Parser for the input arguments
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('files_or_folders', 
+                        ## Store the argument in files_or_folders.
+                        metavar='files_or_folders',
+                        ## Define the input argument type.
+                        type=str,
+                        ## ...
+                        nargs='+',
+                        ## Help string in case the argument is wrong.
+                        help='List of source files or folders.')
+
+    ## Input arguments.
+    args = parser.parse_args()
+
+    extensions = (".h", ".c",
+	          ".hh", ".cc", ".hpp",
+                  ".cpp", ".hxx", ".cxx")
+
+    ## Path to the clang-format binary.
+    clang_format_bin = find_clang_format(['clang-format', 'clang-format-6.0',
+                                          'clang-format-8'])
+    
+    ## clang-format parameters.
+    clang_format_config = load_clang_format_config()
+    ## List of files or directories to parse.
+    list_of_files = list_of_files_to_format(args.files_or_folders,extensions)
+        
+    if not list_of_files:
+        raise RuntimeError(
+            "\nNo file to format, please indicate paths to files or directories.\n")
+    else :
+        print ("\nformatting:")
+        for f in list_of_files:
+            print ("\t"+str(f))
+        print ("")
+
+    execute_clang_format(clang_format_bin, clang_format_config, list_of_files)
+    
+if __name__ == "__main__":
+    """ 
+    Format source files given or found recursively in the given folders.
+    If '--preview' is passed as argument, only list the files that would
+    be formated, without actually formating them.
+    """
+
+    try :
+        _execute()
+    except Exception as e :
+        import traceback
+        traceback.print_exc()
+        print("\nfailed with error:\n"+str(e)+"\n")

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,8 @@ from catkin_pkg.python_setup import generate_distutils_setup
 setup_args = generate_distutils_setup(
     packages=['mpi_cmake_modules'],
     package_dir={'': 'python'},
+    include_package_data=True,
+    package_data={"":["*_clang-format"]},
 )
 
 setup(**setup_args)


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

clang_format was not working (at least for me) when relative paths were passed.
I upgraded it to accept either relative or absolute path. 
I also added more print outs (list of files that will be modified).

## How I Tested

I used it to format several packages in my workspaces, using both relative and absolute paths.
