### PR TITLE
fix a xacro warning problem

### DIFF
--- a/cmake/xacro.cmake
+++ b/cmake/xacro.cmake
@@ -43,6 +43,7 @@ macro(BUILD_XACRO_FILES)
     xacro_add_xacro_file(
       ${xacro_file_full_path}
       ${urdf_file_full_path}
+      INORDER
     )
 
     list(APPEND urdf_files ${urdf_file_full_path})


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Fix a xacro executing warning upon cmake usage

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."


## How I Tested

[//]: # "Explain how you tested your changes"

I used it on the new robot_properties_hermes I am creating, soon uploaded on github.com/machines-in-motion

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
