### PR TITLE
excluding internal folder from documentation. excluding paper.md from…

### DIFF
--- a/resources/Doxyfile.in
+++ b/resources/Doxyfile.in
@@ -46,6 +46,10 @@ GENERATE_TREEVIEW = YES
 EXCLUDE_PATTERNS       = */*deprecated*/*
 EXCLUDE_PATTERNS      += */*build*/*
 EXCLUDE_PATTERNS      += */tests/*
+EXCLUDE_PATTERNS      += */internal/*
+
+# removing joss paper
+EXCLUDE_PATTERNS      += */paper.md
 
 GENERATE_TAGFILE       = @PROJECT_NAME@.tag
 GENERATE_HTML          = YES

--- a/resources/sphinx/doxygen/Doxyfile.in
+++ b/resources/sphinx/doxygen/Doxyfile.in
@@ -35,6 +35,7 @@ EXCLUDE_PATTERNS       = */*deprecated*/*
 EXCLUDE_PATTERNS      += */*build*/*
 EXCLUDE_PATTERNS      += */tests/*
 EXCLUDE_PATTERNS      += */resources/*
+EXCLUDE_PATTERNS      += */internal/*
 RECURSIVE              = YES
 GENERATE_LATEX         = No
 GENERATE_TAGFILE       = @DOXYGEN_OUTPUT@/@PROJECT_NAME@.tag

--- a/resources/sphinx/sphinx/conf.py.in
+++ b/resources/sphinx/sphinx/conf.py.in
@@ -106,7 +106,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = []
+exclude_patterns = ["internal/*"]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None


### PR DESCRIPTION
added to both doxygen and sphinx a pattern for exclusion of "internal" folder, to allow exclusion of internal header and cpp files.

added to doxygen a pattern for exclusion of paper.md file, which is a file required for publication in JOSS, but that should not appear in the documentation (this file did not seem to be an issue for sphinx) 


