### PR TITLE
Add napoleon to sphinx configuration

### DIFF
--- a/resources/sphinx/sphinx/conf.py.in
+++ b/resources/sphinx/sphinx/conf.py.in
@@ -60,6 +60,7 @@ release = version_xml
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',


### PR DESCRIPTION
## Description

Napoleon is a Sphinx extension that provides support for Google- and
NumPy-Style docstrings.


## How I Tested

By building the documentation for trifinger_simulation, which uses Google style docstrings (left is without, right with napoleon):

![merged](https://user-images.githubusercontent.com/9333121/89898367-e20ecf00-dbe0-11ea-8099-51ec5dcbd8b2.png)


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
