### PR TITLE
Update preempt_rt regex

### DIFF
--- a/cmake/os_detection.cmake
+++ b/cmake/os_detection.cmake
@@ -33,7 +33,7 @@ macro(DEFINE_OS)
     set(CURRENT_OS "xenomai")
     add_definitions("-DXENOMAI")
     
-  elseif(OS_VERSION MATCHES "preempt rt" OR OS_VERSION MATCHES "preempt-rt")
+  elseif(OS_VERSION MATCHES "preempt rt" OR OS_VERSION MATCHES "preempt-rt" OR OS_VERSION MATCHES "preempt_rt")
     set(CURRENT_OS "rt-preempt")
     add_definitions("-DRT_PREEMPT")
     


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."

My version of preempt_rt patch (5.4.59-rt36) has the output of `uname -a` match `PREEMPT_RT`, which fails the regex check.

## How I Tested

[//]: # "Explain how you tested your changes"

Compilation proceeds using this simple modification, and does not otherwise.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
