### PR TITLE
Use Python 3 for the code formatter scripts

### DIFF
--- a/cmake/get_python_install_dir.cmake
+++ b/cmake/get_python_install_dir.cmake
@@ -16,7 +16,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/get_python_interpreter.cmake)
 function(get_python_install_dir output)
 
   # Find the python interpreter.
-  get_python_interpreter(python_interpreter)
+  find_package(Python REQUIRED)
 
   # code to find installation path for python libs
   set(_python_code
@@ -27,14 +27,14 @@ function(get_python_install_dir output)
       "rel_path = os.path.relpath(python_lib, start=install_path)"
       "print(rel_path.replace(os.sep, '/'))")
   execute_process(
-    COMMAND "${python_interpreter}" "-c" "${_python_code}"
+    COMMAND "${Python_EXECUTABLE}" "-c" "${_python_code}"
     OUTPUT_VARIABLE _output
     RESULT_VARIABLE _result
     OUTPUT_STRIP_TRAILING_WHITESPACE)
   if(NOT _result EQUAL 0)
     message(
       FATAL_ERROR
-        "execute_process(${python_interpreter} -c '${_python_code}') returned "
+        "execute_process(${Python_EXECUTABLE} -c '${_python_code}') returned "
         "error code ${_result}")
   endif()
   set(${output}

--- a/scripts/mpi_cmake_format
+++ b/scripts/mpi_cmake_format
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """mpi_cmake_format
 

--- a/scripts/mpi_code_format
+++ b/scripts/mpi_code_format
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """mpi_code_format
 

--- a/scripts/mpi_cpp_format
+++ b/scripts/mpi_cpp_format
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """mpi_cpp_format
 

--- a/scripts/mpi_python_format
+++ b/scripts/mpi_python_format
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 """mpi_python_format
 


### PR DESCRIPTION
## Description

I had problems using the `mpi_*_format` commands because they get installed for Python 2 but the ROS 2 workspace sets everything up for Python 3.

This PR changes the formatting scripts to all run in Python 3.

Regarding finding Python in CMake: `get_python_interpreter()` apparently finds Python 2, so I replaced it with `find_package(Python)` which prefers Python 3 if both are present.

Please let me know in case it still needs to work with Python 2 somewhere, then we need to find another solution.

## How I Tested

By running the `mpi_*_format` scripts in my workspace.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
