### PR TITLE
Allow specifying target OS by setting OS_VERSION

### DIFF
--- a/cmake/os_detection.cmake
+++ b/cmake/os_detection.cmake
@@ -11,35 +11,42 @@
 #
 # .. cmake:command:: DEFINE_OS
 #
-#   Execute "uname --all" which provides us information on the *OS* specific
-#   functions to use.
-#   This method supports::
-#       * Xenomai
-#       * RT-Preempt
-#       * Ubuntu
-#       * Mac-OS
+#   Executes ``uname -a`` to detect the OS and sets some flags accordingly.
+#   Alternatively, the target OS can explicitly be specified by setting the
+#   variable ``OS_VERSION`` before calling this macro (useful for cross
+#   compiling).
+#
+#   Supported OS_VERSIONs are::
+#
+#       * "xenomai"
+#       * "preempt-rt"
+#       * "non-real-time"/"ubuntu"
+#       * "darwin" (Mac-OS)
 #
 #   It also discriminate between real-time and non-real-time *OS*.
 #
 macro(DEFINE_OS)
 
   # Update submodules as needed
-  execute_process(
-      COMMAND uname -a
-      OUTPUT_VARIABLE UNAME_OUT)
-  string(TOLOWER "${UNAME_OUT}" OS_VERSION)
+  if (NOT DEFINED OS_VERSION)
+      execute_process(
+          COMMAND uname -a
+          OUTPUT_VARIABLE UNAME_OUT)
+      string(TOLOWER "${UNAME_OUT}" OS_VERSION)
+  endif()
 
   if(OS_VERSION MATCHES "xenomai")
     set(CURRENT_OS "xenomai")
     add_definitions("-DXENOMAI")
-    
+
   elseif(OS_VERSION MATCHES "preempt rt" OR OS_VERSION MATCHES "preempt-rt" OR OS_VERSION MATCHES "preempt_rt")
     set(CURRENT_OS "rt-preempt")
     add_definitions("-DRT_PREEMPT")
-    
+
   elseif(OS_VERSION MATCHES "ubuntu" OR OS_VERSION MATCHES "non-real-time" OR OS_VERSION MATCHES "darwin" OR OS_VERSION MATCHES "el7.x86_64")
     set(CURRENT_OS "non-real-time")
     add_definitions("-DNON_REAL_TIME")
+
   else()
     message(STATUS "output of \"uname -a\": ${OS_VERSION}")
     message(WARNING "Could not detect the OS version please "
@@ -47,9 +54,9 @@ macro(DEFINE_OS)
     set(CURRENT_OS "non-real-time")
     add_definitions("-DNON_REAL_TIME")
   endif()
-  #
+
   message(STATUS "The OS type is " ${CURRENT_OS})
-  
+
   if(OS_VERSION MATCHES "darwin")
     add_definitions("-DMAC_OS")
     message(STATUS "OS found is MAC_OS")


### PR DESCRIPTION
## Description

For a normal build (`colcon build`), this should not change anything
(i.e. OS gets auto-detected).  However, it is now possible to specify
the target OS at build time for cross compilation:

    colcon build --cmake-args -DOS_VERSION=preempt-rt

What is a bit annoying with this solution is that for each package not directly using `OS_VERSION` (which is almost every package), cmake prints a warning:
> CMake Warning:
>  Manually-specified variables were not used by the project:
>    OS_VERSION

Is there maybe a better way to pass this argument?

## How I Tested

By creating two singularity images on my non-real-time PC, one with a normal build and one with setting `OS_VERSION=preempt-rt`.  Then running both on the TriFinger robot.
- As expected, the normal build prints a "this is not going to run in real time" warning and fails with a timing warning after some time.
- The preempt-rt build does not print the warning and was running without timing error, so it seems to be working :)



## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
