### PR TITLE
clang-format: Preserve include blocks

### DIFF
--- a/resources/_clang-format
+++ b/resources/_clang-format
@@ -5,6 +5,7 @@ AllowShortFunctionsOnASingleLine: None
 BinPackArguments: 'false'
 BinPackParameters: 'false'
 BreakBeforeBraces: Allman
+IncludeBlocks: Preserve
 IndentWidth: '4'
 
 ...


### PR DESCRIPTION

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Explicitly tell clang-format to preserve include blocks when sorting
includes.  For example

    #include <a.h>
    #include <c.h>

    #include <b.h>

should not be not changed.  Without this setting the two blocks are
merged into one in newer clang versions:

    #include <a.h>
    #include <b.h>
    #include <c.h>

Note: It seems that the default behaviour of clang-format changed.  It
was okay without this using version 6 but is needed with version 9.


## How I Tested

Formatting code with clang-format-6 and with clangd-9 (which I assume corresponds to using clang-format-9)
