### PR TITLE
Allow README.rst as alternative to README.md

### DIFF
--- a/cmake/sphinx.cmake
+++ b/cmake/sphinx.cmake
@@ -311,7 +311,20 @@ macro(ADD_SPHINX_DOCUMENTATION)
     endif(${md_file_lower} STREQUAL "readme.md")
   endforeach(md_file ${md_files})
   if(NOT readme_file)
-    message(FATAL_ERROR "No readme file found.")
+      file(
+        GLOB rst_files
+        RELATIVE ${PROJECT_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}/*.rst)
+      foreach(rst_file ${rst_files})
+        string(TOLOWER ${rst_file} rst_file_lower)
+        if(${rst_file_lower} STREQUAL "readme.rst")
+          set(readme_file ${rst_file})
+        endif(${rst_file_lower} STREQUAL "readme.rst")
+      endforeach(rst_file ${rst_files})
+
+      if(NOT readme_file)
+        message(FATAL_ERROR "No readme file found.")
+      endif()
   endif()
   add_custom_target(
     ${PROJECT_NAME}_readme_symlink

--- a/cmake/sphinx.cmake
+++ b/cmake/sphinx.cmake
@@ -125,6 +125,29 @@ macro(_BUILD_SPHINX_BUILD)
 
 endmacro(_BUILD_SPHINX_BUILD)
 
+
+#.rst:
+#
+# .. cmake:command:: _FIND_README
+#
+#    Search for a README with the given file extension and, if found, return
+#    its name using ``OUTPUT_VAR``.  Example to search for 'readme.md'::
+#
+#        _FIND_README(readme_file "md")
+#
+macro(_FIND_README OUTPUT_VAR EXTENSION)
+  file(
+    GLOB files
+    RELATIVE ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/*.${EXTENSION})
+  foreach(file ${files})
+    string(TOLOWER ${file} file_lower)
+    if(${file_lower} STREQUAL "readme.${EXTENSION}")
+      set(${OUTPUT_VAR} ${file})
+    endif()
+  endforeach()
+endmacro()
+
 #.rst:
 #
 # .. cmake:command:: ADD_SPHINX_DOCUMENTATION
@@ -300,31 +323,14 @@ macro(ADD_SPHINX_DOCUMENTATION)
     IMMEDIATE)
 
   # Fetch the readme.md and the license.txt
-  file(
-    GLOB md_files
-    RELATIVE ${PROJECT_SOURCE_DIR}
-    ${PROJECT_SOURCE_DIR}/*.md)
-  foreach(md_file ${md_files})
-    string(TOLOWER ${md_file} md_file_lower)
-    if(${md_file_lower} STREQUAL "readme.md")
-      set(readme_file ${md_file})
-    endif(${md_file_lower} STREQUAL "readme.md")
-  endforeach(md_file ${md_files})
+  _FIND_README(readme_file "md")
   if(NOT readme_file)
-      file(
-        GLOB rst_files
-        RELATIVE ${PROJECT_SOURCE_DIR}
-        ${PROJECT_SOURCE_DIR}/*.rst)
-      foreach(rst_file ${rst_files})
-        string(TOLOWER ${rst_file} rst_file_lower)
-        if(${rst_file_lower} STREQUAL "readme.rst")
-          set(readme_file ${rst_file})
-        endif(${rst_file_lower} STREQUAL "readme.rst")
-      endforeach(rst_file ${rst_files})
+    # If no "readme.md" is found, let's check if there is a "readme.rst"
+    _FIND_README(readme_file "rst")
 
-      if(NOT readme_file)
-        message(FATAL_ERROR "No readme file found.")
-      endif()
+    if(NOT readme_file)
+      message(FATAL_ERROR "No readme file found.")
+    endif()
   endif()
   add_custom_target(
     ${PROJECT_NAME}_readme_symlink

--- a/python/mpi_cmake_modules/documentation_builder.py
+++ b/python/mpi_cmake_modules/documentation_builder.py
@@ -505,8 +505,11 @@ def build_documentation(build_dir, project_source_dir, project_version):
     readme = [
         p.resolve()
         for p in Path(project_source_dir).glob("*")
-        if p.name.lower() == "readme.md"
+        if p.name.lower() in ["readme.md", "readme.rst"]
     ]
+    # sort alphabetically so that "readme.md" is preferred in case both are
+    # found
+    readme = sorted(readme)
     if readme:
         shutil.copy(str(readme[0]), doc_build_dir / "readme.md")
 


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

If no README.md is found, check if there is a README.rst.  Fortunately,
the documentation build already supports both independent of the file
extension, so the build works in both cases.

If both md and rst are there, md is used.


## How I Tested

By building documentation for both cases.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
