### PR TITLE
Use install(PROGRAMS ...) for scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,14 +67,13 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/cmake/
 #
 # install the scripts.
 # cmake-format: off
-install(FILES 
+install(PROGRAMS
   scripts/mpi_cpp_format
   scripts/mpi_python_format
   scripts/mpi_cmake_format
   scripts/mpi_code_format
   scripts/mpi_doc_build
-  DESTINATION bin
-  PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE)
+  DESTINATION bin)
 # cmake-format: on
 # install their configuration files.
 install(DIRECTORY resources DESTINATION ${python_install_dir}/${PROJECT_NAME})


### PR DESCRIPTION
## Description

The previous command only set the executable flag for the owner of the
scripts, which is a problem if it is supposed to be used by other users
as well (e.g. in a container that is build by root but then used by
"normal" users).

Instead use `install(PROGRAMS ...)` which takes care of the permissions.
With this, the installed scripts have permissions `-rwxr-xr-x`, allowing
all users to execute them.


## How I Tested

Checked permissions of installed scripts.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
