### PR TITLE
fix (sphinx): Do not list index.rst inside itself

### DIFF
--- a/resources/sphinx/sphinx/index.rst.in
+++ b/resources/sphinx/sphinx/index.rst.in
@@ -1,10 +1,5 @@
 @HEADER@
 
-.. toctree::
-   :hidden:
-
-   index.rst
-
 .. mdinclude:: readme.md
 
 @GENERAL_DOCUMENTATION@


### PR DESCRIPTION
Listing index.rst in a toctree inside itself results in build warnings
and a messed up navigation bar where everything appears twice.

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Listing index.rst in a toctree inside itself results in the following build warnings:

    .../index.rst: WARNING: self referenced toctree found. Ignored.
    .../index.rst: WARNING: circular toctree references detected, ignoring: index <- index

After removing it, the warnings are gone and also the messed up navigation menu (where everything appears twice) is fixed now.  Left is before, right after:

![image](https://user-images.githubusercontent.com/9333121/140365108-dfbd693b-2b0a-4010-a97a-a82c1fba9c7e.png)


## How I Tested

Building the docs of trifinger_object_tracking (see screenshot above).


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
