### PR TITLE
documentation build: Use Python package at install location in cmake build and improve Python doc builder

### DIFF
--- a/cmake/sphinx.cmake
+++ b/cmake/sphinx.cmake
@@ -173,6 +173,14 @@ macro(ADD_SPHINX_DOCUMENTATION)
 
   # All parameters
 
+  # TODO: This should probably be handled in a nicer way that is more obvious to
+  # the user (probably via an argument that has to be passed?
+  if (DEFINED PYTHON_INSTALL_DIR)
+    set(PYTHON_PACKAGE_LOCATION ${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR})
+  else()
+    set(PYTHON_PACKAGE_LOCATION ${PROJECT_SOURCE_DIR}/python)
+  endif()
+
   # Build and install directories
   set(SPHINX_DOC_BUILD_FOLDER ${CMAKE_BINARY_DIR}/share/docs/sphinx)
   set(SPHINX_DOC_INSTALL_FOLDER share/${PROJECT_NAME}/docs/sphinx)
@@ -188,7 +196,7 @@ macro(ADD_SPHINX_DOCUMENTATION)
   set(BREATHE_OUTPUT ${SPHINX_DOC_BUILD_FOLDER}/breathe_apidoc)
   set(BREATHE_OPTION -g union,namespace,class,group,struct,file,interface)
   # Sphinx apidoc
-  set(SPHINX_APIDOC_INPUT ${PROJECT_SOURCE_DIR}/python/${PROJECT_NAME})
+  set(SPHINX_APIDOC_INPUT ${PYTHON_PACKAGE_LOCATION}/${PROJECT_NAME})
   set(SPHINX_APIDOC_OUTPUT ${SPHINX_DOC_BUILD_FOLDER})
   # Shinx build
   set(SPHINX_BUILD_INPUT ${SPHINX_DOC_BUILD_FOLDER})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.black]
+line-length = 79
+
+[tool.pylint.messages_control]
+disable = "C0330, C0326"

--- a/python/mpi_cmake_modules/documentation_builder.py
+++ b/python/mpi_cmake_modules/documentation_builder.py
@@ -525,3 +525,15 @@ def build_documentation(build_dir, project_source_dir, project_version):
     # Generate the html doc
     #
     _build_sphinx_build(doc_build_dir)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--build-dir", type=str, help="Build directory")
+    parser.add_argument("--project-dir", type=str, help="Package directory?")
+    parser.add_argument("--project-version", type=str, help="Package version")
+    args = parser.parse_args()
+
+    build_documentation(args.build_dir, args.project_dir, args.project_version)

--- a/python/mpi_cmake_modules/documentation_builder.py
+++ b/python/mpi_cmake_modules/documentation_builder.py
@@ -6,6 +6,7 @@ License BSD-3-Clause
 Copyright (c) 2021, New York University and Max Planck Gesellschaft.
 """
 
+import argparse
 import subprocess
 import shutil
 import fnmatch
@@ -587,8 +588,6 @@ def build_documentation(
 
 
 def main():
-    import argparse
-
     def AbsolutePath(path):
         return Path(path).absolute()
 

--- a/python/mpi_cmake_modules/documentation_builder.py
+++ b/python/mpi_cmake_modules/documentation_builder.py
@@ -10,6 +10,7 @@ import subprocess
 import shutil
 import fnmatch
 import textwrap
+import os
 from pathlib import Path
 
 import mpi_cmake_modules
@@ -163,7 +164,7 @@ def _build_doxygen_xml(doc_build_dir, project_source_dir):
         doxyfile_out_text = (
             f.read()
             .replace("@PROJECT_NAME@", project_name)
-            .replace("@PROJECT_SOURCE_DIR@", project_source_dir)
+            .replace("@PROJECT_SOURCE_DIR@", os.fspath(project_source_dir))
             .replace("@DOXYGEN_FILE_PATTERNS@", doxygen_file_patterns)
             .replace("@DOXYGEN_OUTPUT@", str(doxygen_output))
         )
@@ -523,7 +524,7 @@ def build_documentation(
     ) as f:
         out_text = (
             f.read()
-            .replace("@PROJECT_SOURCE_DIR@", project_source_dir)
+            .replace("@PROJECT_SOURCE_DIR@", os.fspath(project_source_dir))
             .replace("@PROJECT_NAME@", project_name)
             .replace("@PROJECT_VERSION@", project_version)
             .replace(
@@ -564,17 +565,23 @@ def build_documentation(
 if __name__ == "__main__":
     import argparse
 
+    def AbsolutePath(path):
+        return Path(path).absolute()
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--build-dir", required=True, type=str, help="Build directory"
+        "--build-dir", required=True, type=AbsolutePath, help="Build directory"
     )
     parser.add_argument(
-        "--package-dir", required=True, type=str, help="Package directory"
+        "--package-dir",
+        required=True,
+        type=AbsolutePath,
+        help="Package directory",
     )
     # FIXME relative path with ../../ not working...
     parser.add_argument(
         "--python-dir",
-        type=str,
+        type=AbsolutePath,
         help="""Directory containing the Python package.  If not set, it is
             auto-detected inside the package directory
         """,

--- a/python/mpi_cmake_modules/documentation_builder.py
+++ b/python/mpi_cmake_modules/documentation_builder.py
@@ -425,11 +425,22 @@ def _search_for_cmake_api(doc_build_dir, project_source_dir, resource_dir):
 
 
 def _search_for_general_documentation(
-    doc_build_dir, project_source_dir, resource_dir
-):
+    doc_build_dir: Path, project_source_dir: Path, resource_dir: Path
+) -> str:
     general_documentation = ""
+
+    doc_path_candidates = [
+        project_source_dir / "doc",
+        project_source_dir / "docs",
+    ]
+    doc_path = None
+    for p in doc_path_candidates:
+        if p.is_dir():
+            doc_path = p
+            break
+
     # Search for additional doc.
-    if (Path(project_source_dir) / "doc").is_dir():
+    if doc_path:
         general_documentation = textwrap.dedent(
             """
             .. toctree::
@@ -445,11 +456,11 @@ def _search_for_general_documentation(
             / "sphinx"
             / "sphinx"
             / "general_documentation.rst.in",
-            str(doc_build_dir / "general_documentation.rst"),
+            doc_build_dir / "general_documentation.rst",
         )
         shutil.copytree(
-            str(Path(project_source_dir) / "doc"),
-            str(doc_build_dir / "doc"),
+            doc_path,
+            doc_build_dir / "doc",
         )
     return general_documentation
 
@@ -578,7 +589,6 @@ if __name__ == "__main__":
         type=AbsolutePath,
         help="Package directory",
     )
-    # FIXME relative path with ../../ not working...
     parser.add_argument(
         "--python-dir",
         type=AbsolutePath,

--- a/python/mpi_cmake_modules/documentation_builder.py
+++ b/python/mpi_cmake_modules/documentation_builder.py
@@ -346,10 +346,20 @@ def _search_for_python_api(doc_build_dir, project_source_dir):
     # Get the project name form the source path.
     project_name = Path(project_source_dir).name
 
+    package_path_candidates = [
+        Path(project_source_dir) / project_name,
+        Path(project_source_dir) / "python" / project_name,
+        Path(project_source_dir) / "src" / project_name,
+    ]
+
+    package_path = None
+    for p in package_path_candidates:
+        if p.is_dir():
+            package_path = p
+            break
+
     # Search for Python API.
-    if (Path(project_source_dir) / "python" / project_name).is_dir() or (
-        Path(project_source_dir) / "src" / project_name
-    ).is_dir():
+    if package_path:
         # Introduce this toc tree in the main index.rst
         python_api = textwrap.dedent(
             """
@@ -363,14 +373,7 @@ def _search_for_python_api(doc_build_dir, project_source_dir):
 
         """
         )
-        if (Path(project_source_dir) / "python" / project_name).is_dir():
-            _build_sphinx_api_doc(
-                doc_build_dir, Path(project_source_dir) / "python"
-            )
-        if (Path(project_source_dir) / "src" / project_name).is_dir():
-            _build_sphinx_api_doc(
-                doc_build_dir, Path(project_source_dir) / "src"
-            )
+        _build_sphinx_api_doc(doc_build_dir, package_path)
     return python_api
 
 

--- a/python/mpi_cmake_modules/documentation_builder.py
+++ b/python/mpi_cmake_modules/documentation_builder.py
@@ -8,7 +8,9 @@ Copyright (c) 2021, New York University and Max Planck Gesellschaft.
 
 import subprocess
 import shutil
+import fnmatch
 from pathlib import Path
+
 import mpi_cmake_modules
 from mpi_cmake_modules.utils import which
 
@@ -281,12 +283,16 @@ def _search_for_cpp_api(doc_build_dir, project_source_dir, resource_dir):
     cpp_api = ""
 
     # Search for C++ API:
+    # TODO: this search is overly expensive for just checking if there are any cpp files
+    # (could stop at first match)
     cpp_files = [
         p.resolve()
         for p in Path(project_source_dir).glob("**/*")
-        if p.suffix in _get_cpp_file_patterns().split()
+        if any(fnmatch.fnmatch(p, pattern) for pattern in _get_cpp_file_patterns())
     ]
     if cpp_files:
+        print("Found C++ files, add C++ API documentation")
+
         # Introduce this toc tree in the main index.rst
         cpp_api = (
             "C++ API\n"
@@ -314,6 +320,9 @@ def _search_for_cpp_api(doc_build_dir, project_source_dir, resource_dir):
         _build_doxygen_xml(doc_build_dir, project_source_dir)
         # Generate the .rst corresponding to the doxygen xml
         _build_breath_api_doc(doc_build_dir)
+
+    else:
+        print("No C++ files found.")
 
     return cpp_api
 

--- a/python/mpi_cmake_modules/documentation_builder.py
+++ b/python/mpi_cmake_modules/documentation_builder.py
@@ -229,6 +229,7 @@ def _build_sphinx_api_doc(doc_build_dir, python_source_dir):
         sphinx_apidoc_input = str(python_source_dir)
         bashCommand = (
             sphinx_apidoc
+            + " --separate "
             + " -o "
             + str(sphinx_apidoc_output)
             + " "

--- a/python/mpi_cmake_modules/documentation_builder.py
+++ b/python/mpi_cmake_modules/documentation_builder.py
@@ -9,6 +9,7 @@ Copyright (c) 2021, New York University and Max Planck Gesellschaft.
 import subprocess
 import shutil
 import fnmatch
+import textwrap
 from pathlib import Path
 
 import mpi_cmake_modules
@@ -294,12 +295,15 @@ def _search_for_cpp_api(doc_build_dir, project_source_dir, resource_dir):
         print("Found C++ files, add C++ API documentation")
 
         # Introduce this toc tree in the main index.rst
-        cpp_api = (
-            "C++ API\n"
-            "-------\n\n"
-            ".. toctree::\n"
-            "   :maxdepth: 2\n\n"
-            "   doxygen_index\n\n"
+        cpp_api = textwrap.dedent(
+            """
+            .. toctree::
+               :caption: C++ API
+               :maxdepth: 2
+
+               doxygen_index
+
+        """
         )
         # Copy the index of the C++ API.
         shutil.copy(
@@ -347,13 +351,17 @@ def _search_for_python_api(doc_build_dir, project_source_dir):
         Path(project_source_dir) / "src" / project_name
     ).is_dir():
         # Introduce this toc tree in the main index.rst
-        python_api = (
-            "Python API\n"
-            "----------\n\n"
-            "* :ref:`modindex`\n\n"
-            ".. toctree::\n"
-            "   :maxdepth: 3\n\n"
-            "   modules\n\n"
+        python_api = textwrap.dedent(
+            """
+            .. toctree::
+               :caption: Python API
+               :maxdepth: 3
+
+               modules
+
+            * :ref:`modindex`
+
+        """
         )
         if (Path(project_source_dir) / "python" / project_name).is_dir():
             _build_sphinx_api_doc(
@@ -377,12 +385,15 @@ def _search_for_cmake_api(doc_build_dir, project_source_dir, resource_dir):
     ]
     if cmake_files:
         # Introduce this toc tree in the main index.rst
-        cmake_api = (
-            "CMake API\n"
-            "---------\n"
-            ".. toctree::\n"
-            "   :maxdepth: 3\n\n"
-            "   cmake_doc\n\n"
+        cmake_api = textwrap.dedent(
+            """
+            .. toctree::
+               :caption: CMake API
+               :maxdepth: 3
+
+               cmake_doc
+
+        """
         )
         doc_cmake_module = ""
         for cmake_file in cmake_files:
@@ -412,11 +423,15 @@ def _search_for_general_documentation(
     general_documentation = ""
     # Search for additional doc.
     if (Path(project_source_dir) / "doc").is_dir():
-        general_documentation = (
-            "General Documentation\n---------------------\n"
-            ".. toctree::\n"
-            "   :maxdepth: 2\n\n"
-            "   general_documentation\n\n"
+        general_documentation = textwrap.dedent(
+            """
+            .. toctree::
+               :caption: General Documentation
+               :maxdepth: 2
+
+               general_documentation
+
+        """
         )
         shutil.copy(
             resource_dir

--- a/python/mpi_cmake_modules/documentation_builder.py
+++ b/python/mpi_cmake_modules/documentation_builder.py
@@ -17,7 +17,7 @@ from mpi_cmake_modules.utils import which
 
 
 def _get_cpp_file_patterns():
-    return "*.h *.hh *.hpp *.hxx *.cpp *.c *.cc"
+    return ["*.h", "*.hh", "*.hpp", "*.hxx", "*.cpp", "*.c", "*.cc"]
 
 
 def _find_doxygen():
@@ -153,7 +153,7 @@ def _build_doxygen_xml(doc_build_dir, project_source_dir):
     assert doxyfile_in.is_file()
 
     # Which files are going to be parsed.
-    doxygen_file_patterns = _get_cpp_file_patterns()
+    doxygen_file_patterns = " ".join(_get_cpp_file_patterns())
 
     # Where to put the doxygen output.
     doxygen_output = Path(doc_build_dir) / "doxygen"
@@ -284,17 +284,16 @@ def _search_for_cpp_api(doc_build_dir, project_source_dir, resource_dir):
     """
     cpp_api = ""
 
-    # Search for C++ API:
-    # TODO: this search is overly expensive for just checking if there are any cpp files
-    # (could stop at first match)
-    cpp_files = [
-        p.resolve()
-        for p in Path(project_source_dir).glob("**/*")
+    # Search for C++ files
+    has_cpp = False
+    for p in Path(project_source_dir).glob("**/*"):
         if any(
             fnmatch.fnmatch(p, pattern) for pattern in _get_cpp_file_patterns()
-        )
-    ]
-    if cpp_files:
+        ):
+            has_cpp = True
+            break
+
+    if has_cpp:
         print("Found C++ files, add C++ API documentation")
 
         # Introduce this toc tree in the main index.rst

--- a/python/mpi_cmake_modules/documentation_builder.py
+++ b/python/mpi_cmake_modules/documentation_builder.py
@@ -586,7 +586,7 @@ def build_documentation(
     _build_sphinx_build(doc_build_dir)
 
 
-if __name__ == "__main__":
+def main():
     import argparse
 
     def AbsolutePath(path):
@@ -594,7 +594,10 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--build-dir", required=True, type=AbsolutePath, help="Build directory"
+        "--output-dir",
+        required=True,
+        type=AbsolutePath,
+        help="Build directory",
     )
     parser.add_argument(
         "--package-dir",
@@ -609,12 +612,35 @@ if __name__ == "__main__":
             auto-detected inside the package directory
         """,
     )
-    parser.add_argument("--project-version", type=str, help="Package version")
+    parser.add_argument(
+        "--project-version", required=True, type=str, help="Package version"
+    )
+    parser.add_argument(
+        "--force",
+        "-f",
+        action="store_true",
+        help="Do not ask before deleting files.",
+    )
     args = parser.parse_args()
 
+    if not args.force and args.output_dir.exists():
+        print(
+            "Output directory {} already exists."
+            " It will be deleted if you proceed!".format(args.output_dir)
+        )
+        c = input("Continue? [y/N] ")
+
+        if c not in ["y", "Y", "yes"]:
+            print("Abort.")
+            return
+
     build_documentation(
-        args.build_dir,
+        args.output_dir,
         args.package_dir,
         args.project_version,
         python_pkg_path=args.python_dir,
     )
+
+
+if __name__ == "__main__":
+    main()

--- a/resources/sphinx/sphinx/conf.py.in
+++ b/resources/sphinx/sphinx/conf.py.in
@@ -18,9 +18,7 @@ import sys
 from m2r import MdInclude
 from recommonmark.transform import AutoStructify
 
-sys.path.insert(0, os.path.abspath('.'))  # in order to use the local modules
-sys.path.insert(0, os.path.abspath("@PROJECT_SOURCE_DIR@/python"))
-sys.path.insert(0, os.path.abspath("@PROJECT_SOURCE_DIR@/src"))
+sys.path.insert(0, os.path.abspath("@PYTHON_PACKAGE_LOCATION@"))
 
 # cmake parser custom module
 currentmode = "user"

--- a/scripts/mpi_doc_build
+++ b/scripts/mpi_doc_build
@@ -1,41 +1,8 @@
-#!/usr/bin/env python3
+#!/bin/sh
+#
+# Build documentation
+#
+# License BSD-3-Clause
+# Copyright (c) 2021, New York University and Max Planck Gesellschaft.
 
-"""mpi_doc_build
-
-Build documentation
-
-License BSD-3-Clause
-Copyright (c) 2021, New York University and Max Planck Gesellschaft.
-"""
-
-import argparse
-from pathlib import Path
-from mpi_cmake_modules.documentation_builder import (
-    build_documentation,
-)
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="Build the sphinx documentation from a source folder."
-    )
-    parser.add_argument(
-        "build_dir",
-        type=str,
-        help="Directory where to build the documentation",
-    )
-    parser.add_argument(
-        "project_source_dir",
-        type=str,
-        help="Directory where source files are.",
-    )
-    parser.add_argument(
-        "project_version",
-        type=str,
-        help="Directory where source files are.",
-    )
-
-    args = parser.parse_args()
-
-    build_documentation(
-        args.build_dir , args.project_source_dir, args.project_version
-    )
+python3 -m mpi_cmake_modules.documentation_builder "$@"


### PR DESCRIPTION
## Description

Point to the install location of the Python package instead of the source location in Sphinx' `conf.py` and when calling `sphinx-apidoc`. This way modules that are generated at build time (e.g. using pybind11) will be considered.


This fixes two related but distinct issues:

- `sphinx-apidoc` needs to use the install location, otherwise pybind11 modules will not be listed in the generated documentation.
- `sphinx-build` needs to use the install location (done through the change in `conf.py`) as otherwise the pybind11 modules will not be importable at build-time, resulting in even pure Python packages which import them internally to cause an error and thus to be excluded from the generated documentation.

WIP:
Before merging, the following points need to be considered:
- [ ] The change in `conf.py` will break the Python builder of the documentation.  Not sure how to best handle this.  Maybe by simply adding an `if/else`?  I think in the long term, we should actually get rid of this duplicate setup (maybe by having a standalone documentation builder which can be called both from Python and CMake or even independent of the build?).
- [ ] Just checking for the existence of `PYTHON_INSTALL_DIR` internally is not the best solution, maybe better use an argument to the macro.
- [ ] We need to ensure that the documentation is built _after_ all Python modules are built/installed.  I think right now, it may fail on a clean rebuild.  Is there a way to achieve this without manually specifying dependencies?


## How I Tested

By building the documentation of the robot_fingers package (using cmake).



## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [ ] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
