### PR TITLE
fix: Check for Python at the PYTHON_PACKAGE_LOCATION

### DIFF
--- a/cmake/sphinx.cmake
+++ b/cmake/sphinx.cmake
@@ -263,7 +263,7 @@ macro(ADD_SPHINX_DOCUMENTATION)
   endif()
   # Build the Python API rst files if needed
   set(PYTHON_API "")
-  if(IS_DIRECTORY ${PROJECT_SOURCE_DIR}/python)
+  if(IS_DIRECTORY ${PYTHON_PACKAGE_LOCATION})
 
     # Add the Python API to the main documentation
     set(PYTHON_API


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

It should check at the location that is actually used later to generate the doc.  This also makes it work for packages that do not store the Python code in `python/` (a convention from which I'm starting to deviate because it makes things easier for some editors if the Python package is found at the root of the repo).

## How I Tested

By running it locally with robot_fingers.



## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
