### PR TITLE
os detection: lowlatency kernel treated as preempt-rt kernel

### DIFF
--- a/cmake/os_detection.cmake
+++ b/cmake/os_detection.cmake
@@ -19,11 +19,11 @@
 #   Supported OS_VERSIONs are::
 #
 #       * "xenomai"
-#       * "preempt-rt"
+#       * "preempt-rt" / "lowlatency"
 #       * "non-real-time"/"ubuntu"
 #       * "darwin" (Mac-OS)
 #
-#   It also discriminate between real-time and non-real-time *OS*.
+#   It also discriminate between real-time and non-real-time (or low latency) *OS* (kernel).
 #
 macro(DEFINE_OS)
 

--- a/cmake/os_detection.cmake
+++ b/cmake/os_detection.cmake
@@ -39,7 +39,7 @@ macro(DEFINE_OS)
     set(CURRENT_OS "xenomai")
     add_definitions("-DXENOMAI")
 
-  elseif(OS_VERSION MATCHES "preempt rt" OR OS_VERSION MATCHES "preempt-rt" OR OS_VERSION MATCHES "preempt_rt")
+  elseif(OS_VERSION MATCHES "preempt rt" OR OS_VERSION MATCHES "preempt-rt" OR OS_VERSION MATCHES "preempt_rt" OR OS_VERSION MATCHES "lowlatency")
     set(CURRENT_OS "rt-preempt")
     add_definitions("-DRT_PREEMPT")
 


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Setting the same compilation flags for the low latency kernel and the rt-preempt kernel

## How I Tested

Installed the low latency kernel and checked that indeed things were compiling accordingly. 
(note: after installation of the low latency kernel, 'uname -a' displayed something containing "lowlatency" without the need of extra configuration 

