### PR TITLE
Add NO_EXTRAS option to add_pybind11_module()

### DIFF
--- a/cmake/pybind11.cmake
+++ b/cmake/pybind11.cmake
@@ -13,20 +13,30 @@
 #    match the name of the Python module!) followed by a list of source files.
 #
 #    Optional arguments:
+#     - NO_EXTRAS:  Disables some optimisation in pybind11 (see documentation of
+#         pybind11_add_module for details).
 #     - LINK_LIBRARIES:  List of libraries that are linked to the target.
 #     - INLUCDE_DIRS:  List of include directories.  "include" is added by
 #       default.
 #
 macro(add_pybind11_module module_name)
     cmake_parse_arguments(ADD_PYBIND11_MODULE
-        ""  # options without arguments
+        "NO_EXTRAS"  # options without arguments
         ""  # options with single argument
         "INCLUDE_DIRS;LINK_LIBRARIES"  # options with multiple arguments
         ${ARGN}
     )
     set(ADD_PYBIND11_MODULE_SRC ${ADD_PYBIND11_MODULE_UNPARSED_ARGUMENTS})
 
-    pybind11_add_module(${module_name} ${ADD_PYBIND11_MODULE_SRC})
+    if (ADD_PYBIND11_MODULE_NO_EXTRAS)
+        set(NO_EXTRAS "NO_EXTRAS")
+    else()
+        # make sure it is not set
+        unset(NO_EXTRAS)
+    endif()
+
+    # NO_EXTRAS
+    pybind11_add_module(${module_name} ${NO_EXTRAS} ${ADD_PYBIND11_MODULE_SRC})
     target_include_directories(${module_name} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>


### PR DESCRIPTION
## Description

This disables some linker optimisations in pybind11.  Normally one would not want to disable them but there are unresolved cases where the optimisation crashes GCC with an internal compiler error on some machines.
For now the easiest way to unblock this, is to disable the optimisation by setting `NO_EXTRAS`.

For reference, the error is
```
lto1: internal compiler error: in add_symbol_to_partition_1, at lto/lto-partition.c:153
0x7fbddc855082 __libc_start_main
	../csu/libc-start.c:308
Please submit a full bug report,
with preprocessed source if appropriate.
Please include the complete backtrace with any bug report.
See <file:///usr/share/doc/gcc-9/README.Bugs> for instructions.
lto-wrapper: fatal error: /usr/bin/c++ returned 1 exit status
compilation terminated.
/usr/bin/ld: error: lto-wrapper failed
collect2: error: ld returned 1 exit status
```

## How I Tested

By building with both `NO_EXTRAS` set and not set to verify that setting it fixes the GCC failure.



## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
