### PR TITLE
Only add doc target if GENERATE_DOCUMENTATION=ON

### DIFF
--- a/cmake/sphinx.cmake
+++ b/cmake/sphinx.cmake
@@ -46,45 +46,48 @@ macro(ADD_SPHINX_DOCUMENTATION)
     # year or so.
   endif()
 
-  # TODO: This should probably be handled in a nicer way that is more obvious to
-  # the user (probably via an argument that has to be passed?
-  if (DEFINED PYTHON_INSTALL_DIR)
-    set(PYTHON_PACKAGE_LOCATION ${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}/${PROJECT_NAME})
-  else()
-    set(PYTHON_PACKAGE_LOCATION ${PROJECT_SOURCE_DIR}/python/${PROJECT_NAME})
-  endif()
-
-  # Build and install directories
-  set(SPHINX_DOC_BUILD_FOLDER ${CMAKE_BINARY_DIR}/share/docs/sphinx)
-  set(SPHINX_DOC_INSTALL_FOLDER share/${PROJECT_NAME}/docs/sphinx)
-
-
-  # make sure bcat is installed
-  find_program(BCAT bcat)
-  if(NOT BCAT)
-    message(FATAL_ERROR
-        "breathing-cat not found! "
-        "Please install using: pip3 install breathing-cat"
-    )
-  endif()
-
-  # Create the output
-  add_custom_target(
-    ${PROJECT_NAME}_sphinx_html
-    ${BCAT} --package-dir "${PROJECT_SOURCE_DIR}"
-        --output-dir "${SPHINX_DOC_BUILD_FOLDER}"
-        --python-dir "${PYTHON_PACKAGE_LOCATION}"
-        --force
-    COMMENT "Building documentation for ${PROJECT_NAME}"
-  )
-
-  # install the documentation
   if(GENERATE_DOCUMENTATION)
+
+    # TODO: This should probably be handled in a nicer way that is more obvious
+    # to the user (probably via an argument that has to be passed?
+    if (DEFINED PYTHON_INSTALL_DIR)
+      set(PYTHON_PACKAGE_LOCATION
+          ${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}/${PROJECT_NAME})
+    else()
+      set(PYTHON_PACKAGE_LOCATION ${PROJECT_SOURCE_DIR}/python/${PROJECT_NAME})
+    endif()
+
+    # Build and install directories
+    set(SPHINX_DOC_BUILD_FOLDER ${CMAKE_BINARY_DIR}/share/docs/sphinx)
+    set(SPHINX_DOC_INSTALL_FOLDER share/${PROJECT_NAME}/docs/sphinx)
+
+
+    # make sure bcat is installed
+    find_program(BCAT bcat)
+    if(NOT BCAT)
+      message(FATAL_ERROR
+          "breathing-cat not found! "
+          "Please install using: pip3 install breathing-cat"
+      )
+    endif()
+
+    # Create the output
+    add_custom_target(
+      ${PROJECT_NAME}_sphinx_html
+      ${BCAT} --package-dir "${PROJECT_SOURCE_DIR}"
+          --output-dir "${SPHINX_DOC_BUILD_FOLDER}"
+          --python-dir "${PYTHON_PACKAGE_LOCATION}"
+          --force
+      COMMENT "Building documentation for ${PROJECT_NAME}"
+    )
+
+    # install the documentation
     install(DIRECTORY ${SPHINX_DOC_BUILD_FOLDER}/html
             DESTINATION ${SPHINX_DOC_INSTALL_FOLDER})
-  endif()
 
-  # Create a dependency on the doc target
-  add_dependencies(doc ${PROJECT_NAME}_sphinx_html)
+    # Create a dependency on the doc target
+    add_dependencies(doc ${PROJECT_NAME}_sphinx_html)
+
+  endif()
 
 endmacro(ADD_SPHINX_DOCUMENTATION)


### PR DESCRIPTION
## Description

Only add the documentation target and its config if `GENERATE_DOCUMENTATION` is set.  Most importantly, this includes the check for the `bcat` executable, so the normal (non-documentation-)build will not fail anymore if breathing cat is not installed.

Resolves #51.

## How I Tested

Built with and without `-DGENERATE_DOCUMENTATION=ON` and verified with prints that that the `find_program` part is only executed if needed.



## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
